### PR TITLE
Рефакторинг файла plotter_test

### DIFF
--- a/test/plotter_test.rb
+++ b/test/plotter_test.rb
@@ -1,112 +1,104 @@
+require 'tmpdir'
 require 'test_helper'
 require 'plotter'
-require 'chunky_png'
 
 class PlotterTest < Minitest::Test
   include Silicium::Plotter
 
-  @@dir_ready = File.directory?('tmp') || Dir.mkdir('tmp')
+  PATH_TO_TEST_RESOURCES = 'test/resources'
+  attr_accessor :temp_name
+  attr_accessor :needs_teardown
 
-  def images_eql?(filename1, filename2)
-    ChunkyPNG::Image.from_datastream(ChunkyPNG::Datastream.from_file(filename1))
-                    .eql?(ChunkyPNG::Image.from_datastream(ChunkyPNG::Datastream.from_file(filename2)))
+  def setup
+    @temp_name = Dir::Tmpname.create(%w[plot .png]) {}
+    @needs_teardown = false
+    super
+  end
+
+  def teardown
+    File.delete(@temp_name) if @needs_teardown
+    super
+  end
+
+  def draw_image_and_compare(image_params, file_to_compare)
+    plotter = Image.new(image_params[:width], image_params[:height])
+    yield plotter
+    @needs_teardown = true
+    plotter.export(@temp_name)
+
+    assert FileUtils.compare_file(@temp_name, File.join(PATH_TO_TEST_RESOURCES, file_to_compare))
   end
 
   def test_plotter_rectangle
-    # TODO: write method to remove all *.png from tmp before and after running tests
-    filename = 'tmp/rectangle.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(100, 100)
-    plotter.rectangle(Point.new(20, 30), 50, 60, color('black @ 0.5'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 100, height: 100},
+        'rectangle.png') do |plotter|
+      plotter.rectangle(Point.new(20, 30), 50, 60, color('black @ 0.5'))
+    end
   end
 
   def test_bar_chart_1st_quadrant
-    filename = 'tmp/bar_chart_1st_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ 20 => 10, 40 => 20, 80 => 40, 160 => 80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_1st_quadrant.png') do |plotter|
+      plotter.bar_chart({20 => 10, 40 => 20, 80 => 40, 160 => 80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_2nd_quadrant
-    filename = 'tmp/bar_chart_2nd_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ -20 => 10, -40 => 20, -80 => 40, -160 => 80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_2nd_quadrant.png') do |plotter|
+      plotter.bar_chart({-20 => 10, -40 => 20, -80 => 40, -160 => 80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_3rd_quadrant
-    filename = 'tmp/bar_chart_3rd_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ -20 => -10, -40 => -20, -80 => -40, -160 => -80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_3rd_quadrant.png') do |plotter|
+      plotter.bar_chart({-20 => -10, -40 => -20, -80 => -40, -160 => -80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_4th_quadrant
-    filename = 'tmp/bar_chart_4th_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ 20 => -10, 40 => -20, 80 => -40, 160 => -80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_4th_quadrant.png') do |plotter|
+      plotter.bar_chart({20 => -10, 40 => -20, 80 => -40, 160 => -80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_1st2nd_quadrant
-    filename = 'tmp/bar_chart_1st2nd_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ -20 => 10, -40 => 20, -80 => 40, -160 => 80,
-                        20 => 10, 40 => 20, 80 => 40, 160 => 80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_1st2nd_quadrant.png') do |plotter|
+      plotter.bar_chart({-20 => 10, -40 => 20, -80 => 40, -160 => 80,
+                         20 => 10, 40 => 20, 80 => 40, 160 => 80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_3rd4th_quadrant
-    filename = 'tmp/bar_chart_3rd4th_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ -20 => -10, -40 => -20, -80 => -40, -160 => -80,
-                        20 => -10, 40 => -20, 80 => -40, 160 => -80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_3rd4th_quadrant.png') do |plotter|
+      plotter.bar_chart({-20 => -10, -40 => -20, -80 => -40, -160 => -80,
+                         20 => -10, 40 => -20, 80 => -40, 160 => -80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_all_quadrant
-    filename = 'tmp/bar_chart_all_quadrant.png'
-    File.delete(filename) if File.exist?(filename)
-
-    plotter = Image.new(200, 100)
-    plotter.bar_chart({ 20 => -10, -40 => -20, -80 => 40, 160 => 80 }, 1, color('red @ 1.0'))
-    plotter.export(filename)
-
-    assert(images_eql?(filename.sub('tmp', 'test/resources'), filename))
+    draw_image_and_compare(
+        {width: 200, height: 100},
+        'bar_chart_all_quadrant.png') do |plotter|
+      plotter.bar_chart({20 => -10, -40 => -20, -80 => 40, 160 => 80}, 1, color('red @ 1.0'))
+    end
   end
 
   def test_bar_chart_exception
     plotter = Image.new(10, 10)
     assert_raises ArgumentError do
-      plotter.bar_chart({ 20 => -10, 160 => 80 }, 10, color('red @ 1.0'))
+      plotter.bar_chart({20 => -10, 160 => 80}, 10, color('red @ 1.0'))
     end
   end
 

--- a/test/plotter_test.rb
+++ b/test/plotter_test.rb
@@ -1,32 +1,35 @@
 require 'tmpdir'
 require 'test_helper'
 require 'plotter'
+require 'fileutils'
 
 class PlotterTest < Minitest::Test
   include Silicium::Plotter
 
+  TEMP_DIR = "#{Dir.pwd}/tmp"
   PATH_TO_TEST_RESOURCES = 'test/resources'
-  attr_accessor :temp_name
-  attr_accessor :needs_teardown
 
-  def setup
-    @temp_name = Dir::Tmpname.create(%w[plot .png]) {}
-    @needs_teardown = false
-    super
-  end
+  SETUP = begin
+            FileUtils.rm_rf(TEMP_DIR) if Dir.exist?(TEMP_DIR)
+            Dir.mkdir(TEMP_DIR)
+          end
 
-  def teardown
-    File.delete(@temp_name) if @needs_teardown
-    super
+  Minitest.after_run do
+    FileUtils.rm_rf(TEMP_DIR)
   end
 
   def draw_image_and_compare(image_params, file_to_compare)
     plotter = Image.new(image_params[:width], image_params[:height])
     yield plotter
-    @needs_teardown = true
-    plotter.export(@temp_name)
 
-    assert FileUtils.compare_file(@temp_name, File.join(PATH_TO_TEST_RESOURCES, file_to_compare))
+    temp_name = self.get_temp_name
+    plotter.export(temp_name)
+
+    assert FileUtils.compare_file(temp_name, File.join(PATH_TO_TEST_RESOURCES, file_to_compare))
+  end
+
+  def get_temp_name
+    Dir::Tmpname.create(%w[plot .png], TEMP_DIR) {}
   end
 
   def test_plotter_rectangle
@@ -119,4 +122,5 @@ class PlotterTest < Minitest::Test
   def test_plotter_color_2_params
     assert_equal(color('red @ 1.0', nil), 4_278_190_080)
   end
+
 end


### PR DESCRIPTION
Отрефакторил файл plotter_test.rb

- Добавил setup и teardown для удаления временных файлов. Изначальной идеей было вынести создание временной директории и её удаление в setup и teradown которые выоплняются один раз на все тесты, но кажется Minitest так не умеет
- Заменил использование ChunkyPNG на FileUtils для сравнения получаемых изображений. Кажется что это проще чем конструкция с потоками, которая была до этого
- Вынес логику создания и сравнения изображений в отдельный метод